### PR TITLE
Make Python aware of required arguments

### DIFF
--- a/discharge.py
+++ b/discharge.py
@@ -24,6 +24,7 @@ class discharge(object):
        If point: Accesses nearest outlet
        If ring: Accesses all outlets within ring
     upstream: If True, include all upstream ice outlets for any land outlet
+    quiet: If False, print the progress of the current operation
 
     Outputs
     --------
@@ -31,14 +32,8 @@ class discharge(object):
     Returns xarray Dataset if discharge() called
     """
 
-    def __init__(self, base=None, roi=None, upstream=False, quiet=True):
-        if roi is None:
-            print("Error: Not initialized with ROI")
-            return
+    def __init__(self, base, roi, upstream=False, quiet=True):
         self._roi = roi
-        if base is None:
-            print("Error: Not initialized with 'base' folder")
-            return
         self._base = base
         self._quiet = quiet
         self._upstream = upstream


### PR DESCRIPTION
By removing the default value `None` from both required arguments of the constructor of the class `discharge`, Python becomes aware that these two arguments are not optional and will throw an error message if one of them is missing. We can therefore remove the if-statements checking for `None`.

I also added a description to the argument `quiet`.